### PR TITLE
use dotenv files and just raw env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "chrono",
  "deadpool-redis",
  "derive-redis-json",
+ "dotenv",
  "erased-serde",
  "faker",
  "futures",
@@ -266,6 +267,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "erased-serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ chrono = "0.4.31"
 rmp-serde = "1.1.2"
 rmpv = "1.0.1"
 faker = { version = "0.0.4", optional = true }
+dotenv = "0.15.0"
 
 
 # standard crate data is left out

--- a/lib/redis_connection.rs
+++ b/lib/redis_connection.rs
@@ -1,3 +1,4 @@
+use anyhow::Ok;
 pub use async_trait::async_trait;
 pub use deadpool_redis::{
     redis::{AsyncCommands, Client, RedisResult},
@@ -143,4 +144,12 @@ impl RedisOpts<'_> {
             }
         }
     }
+}
+
+pub fn fetch_redis_pass() -> String {
+    use dotenv;
+    if let Err(err) = dotenv::dotenv() {
+        // dothing; continue
+    }
+    std::env::var("REDIS_PASSWORD").unwrap_or_default()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let n = Instant::now();
-    let pass = std::env::var("REDIS_PASSWORD").unwrap_or_default();
+    let pass = fetch_redis_pass();
 
     let mut config = HashMap::new();
     config.insert("password", pass.as_str());

--- a/tests/job_tests.rs
+++ b/tests/job_tests.rs
@@ -16,7 +16,7 @@ mod tests {
             use core::result::Result::Ok;
 
             let mut config = HashMap::new();
-            let pass = std::env::var("REDIS_PASSWORD").unwrap_or_default();
+            let pass = fetch_redis_pass();
             config.insert("password", to_static_str(pass));
             let redis_opts = RedisOpts::Config(config);
             Queue::<'static>::new("test", redis_opts, QueueOptions::default())
@@ -43,7 +43,7 @@ mod tests {
 
     #[tokio_shared_rt::test]
     async fn create_job_from_string() -> anyhow::Result<()> {
-        let pass = std::env::var("REDIS_PASSWORD").unwrap_or_default();
+        let pass = fetch_redis_pass();
 
         let mut config = HashMap::new();
         config.insert("password", pass.as_str());

--- a/tests/queue_tests.rs
+++ b/tests/queue_tests.rs
@@ -13,7 +13,7 @@ mod queue {
     static QUEUE: Lazy<Queue<'static>> = Lazy::const_new(|| {
         Box::pin(async {
             let mut config = HashMap::new();
-            let pass = std::env::var("REDIS_PASSWORD").unwrap_or_default();
+            let pass = fetch_redis_pass();
 
             config.insert("password", to_static_str(pass));
             let redis_opts = RedisOpts::Config(config);


### PR DESCRIPTION
### Changes made:
- [x] added support for using .env files to load variables