### PR TITLE
30 eliminate static lifetime requirement for worker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ redis = {version ="0.23.0",features = ["tokio-comp","streams"]}
 rmp = "0.8.11"
 serde = {version="1.0.160",features=["derive"]}
 serde_json = "1.0.96"
-tokio = {version="1.28.0",features = ["full"]}
+tokio = {version="1.28.0",features = ["fs","rt","rt-multi-thread"]}
 uuid = {version="1.3.3",features = ["v4"]}
 async-event-emitter = "0.1.2"
 chrono = "0.4.31"
-rmp-serde = "1.1.2"
+rmp-serde = "1.1.2" 
 rmpv = "1.0.1"
 faker = { version = "0.0.4", optional = true }
 dotenv = "0.15.0"
@@ -39,4 +39,4 @@ dotenv = "0.15.0"
 [dev-dependencies]
 async-lazy = { version = "0.1.0", features = ["parking_lot"]}
 tokio-shared-rt = "0.1.0"
-tokio = {version="1.28.0",features = ["full"]}
+

--- a/lib/backoff.rs
+++ b/lib/backoff.rs
@@ -1,8 +1,8 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
-type BackoffFn = dyn Fn(i64) -> BoxedFn + Send + Sync;
-pub type BoxedFn = Box<dyn Fn(i64) -> i64 + Send + Sync>;
+type BackoffFn = dyn Fn(i64) -> StoredFn + Send + Sync;
+pub type StoredFn = Arc<dyn Fn(i64) -> i64 + Send + Sync>;
 use anyhow::Ok;
 
 use crate::*;
@@ -17,17 +17,17 @@ impl BackOff {
     pub fn new() -> Self {
         let mut backoff = BackOff::default();
         backoff.register("exponential", |delay: i64| {
-            Box::new(move |atempts: i64| -> i64 { 2_i64.pow(atempts as u32) * delay })
+            Arc::new(move |atempts: i64| -> i64 { 2_i64.pow(atempts as u32) * delay })
         });
 
-        backoff.register("fixed", |delay: i64| Box::new(move |_attempts| delay));
+        backoff.register("fixed", |delay: i64| Arc::new(move |_attempts| delay));
         backoff
     }
 
     pub fn register(
         &mut self,
         name: &'static str,
-        strategy: impl Fn(i64) -> Box<dyn Fn(i64) -> i64 + Send + Sync> + 'static + Send + Sync,
+        strategy: impl Fn(i64) -> Arc<dyn Fn(i64) -> i64 + Send + Sync> + 'static + Send + Sync,
     ) {
         self.builtin_strategies.insert(name, Arc::new(strategy));
     }
@@ -51,15 +51,16 @@ impl BackOff {
         &self,
         backoff_opts: Option<BackOffOptions>,
         atempts: i64,
-        custom_strategy: Option<BoxedFn>,
-    ) -> anyhow::Result<Option<i64>> {
+        custom_strategy: Option<StoredFn>,
+    ) -> Option<i64> {
         if let Some(opts) = backoff_opts {
-            let strategy = self.lookup_strategy(opts, custom_strategy)?;
-            let result = strategy(atempts);
-            return Ok(Some(result));
+            if let Some(strategy) = self.lookup_strategy(opts, custom_strategy) {
+                let calculated_delay = strategy(atempts);
+                return Some(calculated_delay);
+            }
         }
 
-        Ok(None)
+        None
     }
 
     pub fn has_strategy(&self, key: &str) -> bool {
@@ -69,26 +70,25 @@ impl BackOff {
     pub fn lookup_strategy(
         &self,
         backoff: BackOffOptions,
-        custom_strategy: Option<BoxedFn>,
-    ) -> anyhow::Result<BoxedFn>
+        custom_strategy: Option<StoredFn>,
+    ) -> Option<StoredFn>
 where {
         if let (Some(t)) = backoff.type_ {
-            if let Some(strategy) = self.builtin_strategies.get(t.as_str()) {
-                return Ok(strategy(backoff.delay.unwrap()));
+            if let (Some(strategy), Some(delay)) =
+                (self.builtin_strategies.get(t.as_str()), backoff.delay)
+            {
+                return Some(strategy(delay));
             }
-
-            return Err(anyhow::anyhow!("Unknown backoff strategy: {}", t));
         }
 
         if let Some(strategy) = custom_strategy {
-            return Ok(strategy);
+            return Some(strategy);
         }
 
-        Err(anyhow::anyhow!("No backoff strategy specified"))
+        None
     }
 }
 
-//implement std::fmt::Debug for Ba
 impl std::fmt::Debug for BackOff {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BackOff")
@@ -96,36 +96,38 @@ impl std::fmt::Debug for BackOff {
             .finish()
     }
 }
-// write tests for this module
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     #[test]
     fn test_expotential_backoff() {
         let mut backoff = BackOff::new();
-        let strategy = backoff.lookup_strategy(
+        let strategy_found = backoff.lookup_strategy(
             BackOffOptions {
                 delay: Some(100),
                 type_: Some("exponential".to_string()),
             },
             None,
         );
-        //println!("{:?}", backoff);
-        assert_eq!(strategy.unwrap()(1), 200);
+        if let Some(strategy) = strategy_found {
+            assert_eq!(strategy(1), 200);
+        }
     }
 
     #[test]
     fn test_fixed_back() {
         let mut backoff = BackOff::new();
-        let strategy = backoff.lookup_strategy(
+        let strategy_found = backoff.lookup_strategy(
             BackOffOptions {
                 delay: Some(100),
                 type_: Some("fixed".to_string()),
             },
             None,
         );
-
-        assert_eq!(strategy.unwrap()(200), 100);
+        if let Some(strategy) = strategy_found {
+            assert_eq!(strategy(200), 100);
+        }
     }
 }

--- a/lib/job.rs
+++ b/lib/job.rs
@@ -254,7 +254,7 @@ impl<
                 None
             };
 
-            let delay = backoff_s.calculate(backoff, self.attempts_made, custom_strategy)?;
+            let delay = backoff_s.calculate(backoff, self.attempts_made, custom_strategy);
             if let Some(num) = delay {
                 if num == -1 {
                     move_to_failed = true;

--- a/lib/job.rs
+++ b/lib/job.rs
@@ -15,7 +15,7 @@ use std::{borrow::Borrow, clone, collections::HashMap};
 #[derive(Clone)]
 pub struct Job<D, R> {
     pub name: &'static str,
-    pub queue:  Arc<Queue>,
+    pub queue: Arc<Queue>,
     pub timestamp: i64,
     pub attempts_made: i64,
     pub attempts: i64,
@@ -38,7 +38,7 @@ pub struct Job<D, R> {
     pub parent: Option<Parent>,
 }
 // implement Serialize for Job
-impl< D: Serialize, R: Serialize> Serialize for Job< D, R> {
+impl<D: Serialize, R: Serialize> Serialize for Job<D, R> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -75,8 +75,8 @@ impl< D: Serialize, R: Serialize> Serialize for Job< D, R> {
 impl<
         'a,
         D: Deserialize<'a> + Serialize + Clone + std::fmt::Debug + Send + Sync,
-        R: Deserialize<'a> + Serialize + FromRedisValue + Any + Send + Sync + Clone ,
-    > PartialEq for Job< D, R>
+        R: Deserialize<'a> + Serialize + FromRedisValue + Any + Send + Sync + Clone,
+    > PartialEq for Job<D, R>
 {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
@@ -94,7 +94,7 @@ impl<
             + Clone
             + 'static
             + std::fmt::Debug,
-    > Job< D, R>
+    > Job<D, R>
 {
     async fn update_progress<T: Serialize>(&mut self, progress: T) -> anyhow::Result<Option<i8>> {
         self.progress = serde_json::to_string(&progress).unwrap();
@@ -108,8 +108,8 @@ impl<
     }
 
     pub async fn new(
-        name:&str,
-        queue:& Queue,
+        name: &str,
+        queue: &Queue,
         data: D,
         opts: JobOptions,
     ) -> anyhow::Result<Job<D, R>> {
@@ -144,7 +144,11 @@ impl<
             failed_reason: None,
             stack_trace: vec![],
             remove_on_fail: opts.remove_on_fail,
-            scripts: Arc::new(Mutex::new(Scripts::new(prefix.to_string(), queue_name.to_owned(), dup_conn))),
+            scripts: Arc::new(Mutex::new(Scripts::new(
+                prefix.to_string(),
+                queue_name.to_owned(),
+                dup_conn,
+            ))),
             parent_key,
             discarded: false,
             parent,
@@ -376,7 +380,7 @@ impl<
         'a,
         D: Deserialize<'a> + Clone + Serialize + std::fmt::Debug,
         R: Deserialize<'a> + Serialize + std::fmt::Debug,
-    > std::fmt::Debug for Job< D, R>
+    > std::fmt::Debug for Job<D, R>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Job")

--- a/lib/options.rs
+++ b/lib/options.rs
@@ -144,9 +144,9 @@ impl Default for WorkerOptions {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct QueueOptions<'d> {
-    pub prefix: Option<&'d str>,
+#[derive(Debug, Default,Clone)]
+pub struct QueueOptions {
+    pub prefix: Option<&'static str>,
     pub settings: QueueSettings,
 }
 

--- a/lib/options.rs
+++ b/lib/options.rs
@@ -3,7 +3,7 @@
 // properties.
 use crate::redis_connection::RedisOpts;
 use crate::to_static_str;
-use crate::BoxedFn;
+use crate::StoredFn;
 pub use derive_redis_json::RedisJsonValue;
 use rand::prelude::*;
 use redis::{FromRedisValue, RedisError, RedisResult, ToRedisArgs, Value};
@@ -19,15 +19,20 @@ pub struct KeepJobs {
 pub struct JobOptions {
     pub priority: i64,
     pub job_id: Option<String>,
-    pub timestamp: Option<i64>, // timestamp when  the job was created
-    pub delay: i64,             // number of milliseconds to wait until this job can be processed
-    pub attempts: i64,          // total number of attempts to try the job until it completes.
+    pub timestamp: Option<i64>,
+    /// timestamp when  the job was created
+    pub delay: i64,
+    /// number of milliseconds to wait until this job can be processed
+    pub attempts: i64,
+    /// total number of attempts to try the job until it completes.
     pub remove_on_complete: RemoveOnCompletionOrFailure,
     pub remove_on_fail: RemoveOnCompletionOrFailure,
-    pub fail_parent_on_failure: bool, // if true, moves parent to failed
+    pub fail_parent_on_failure: bool,
+    /// if true, moves parent to failed
     pub stacktrace_limit: Option<usize>,
     pub backoff: (i64, Option<BackOffOptions>), //
-    pub lifo: bool, // if true, adds the job to the right of the queue instead of the left
+    pub lifo: bool,
+    /// if true, adds the job to the right of the queue instead of the left
     pub parent: Option<Parent>,
 }
 
@@ -115,7 +120,7 @@ pub struct MetricOptions {
 
 #[derive(Default, Clone)]
 pub struct QueueSettings {
-    pub backoff_strategy: Option<Arc<BoxedFn>>,
+    pub backoff_strategy: Option<Arc<StoredFn>>,
 }
 
 //implement fmt::Debug for QueueSettings
@@ -144,7 +149,7 @@ impl Default for WorkerOptions {
     }
 }
 
-#[derive(Debug, Default,Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct QueueOptions {
     pub prefix: Option<&'static str>,
     pub settings: QueueSettings,

--- a/lib/script.rs
+++ b/lib/script.rs
@@ -11,7 +11,7 @@ pub use redis::Script;
 use redis::{FromRedisValue, RedisResult, ToRedisArgs, Value};
 use rmp::encode;
 use serde::{Deserialize, Serialize};
-  
+
 use std::{collections::HashMap, time};
 pub type ScriptCommands = HashMap<&'static str, Script>;
 use crate::enums::ErrorCode::{self, *};
@@ -20,7 +20,7 @@ use std::any::{self, Any};
 #[derive(Clone)]
 pub struct Scripts {
     pub prefix: String,
-    pub queue_name:String,
+    pub queue_name: String,
     pub keys: HashMap<String, String>,
     pub commands: ScriptCommands,
     pub connection: Pool,
@@ -38,9 +38,8 @@ impl std::fmt::Debug for Scripts {
     }
 }
 
-impl Scripts  {
+impl Scripts {
     pub fn new(prefix: String, queue_name: String, conn: Pool) -> Self {
-        
         let mut keys = HashMap::with_capacity(14);
         let names = [
             "",
@@ -134,7 +133,7 @@ impl Scripts  {
     }
     pub async fn add_job<'s, D: Serialize + Clone, R: FromRedisValue>(
         &mut self,
-        job: &Job <D, R>,
+        job: &Job<D, R>,
     ) -> anyhow::Result<i64> {
         let e = String::from("");
         let prefix = self.keys.get("").unwrap_or(&e);
@@ -250,7 +249,7 @@ impl Scripts  {
         }
         Ok(result)
     }
-    
+
     pub async fn move_to_active(
         &mut self,
         token: &str,
@@ -299,7 +298,7 @@ impl Scripts  {
         V: Any + ToRedisArgs,
     >(
         &mut self,
-        job: &mut Job <D, R>,
+        job: &mut Job<D, R>,
         val: V,
         prop_val: &str,
         should_remove: bool,
@@ -532,7 +531,8 @@ impl Scripts  {
             None => Ok(None),
         }
     }
-    pub async fn move_to_completed<'s,
+    pub async fn move_to_completed<
+        's,
         D: Serialize + Clone,
         R: FromRedisValue + Send + Sync + Clone + 'static,
         V: Any + ToRedisArgs,
@@ -562,7 +562,7 @@ impl Scripts  {
         R: FromRedisValue + Any + Send + Sync + 'static + Clone,
     >(
         &mut self,
-        job: &mut Job< D, R>,
+        job: &mut Job<D, R>,
         failed_reason: String,
         remove_on_failure: bool,
         token: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ async fn main() -> anyhow::Result<()> {
     let pass = fetch_redis_pass();
 
     let mut config = HashMap::new();
-    config.insert("password", pass.as_str());
+    config.insert("password", to_static_str(pass));
     let redis_opts = RedisOpts::Config(config);
     let client = RedisConnection::init(redis_opts.clone()).await?;
 
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
         tokio::fs::read_to_string("test.json").await?
     };
 
-    let queue = Queue::<'_>::new("test", redis_opts, QueueOptions::default()).await?;
+    let queue = Queue::new("test", redis_opts, QueueOptions::default()).await?;
 
     let job = Job::<Data, ReturnedData>::from_json(&queue, contents, "207").await?;
     println!("{:#?}", job);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use bull::*;
 
 use std::collections::HashMap;
 
-use std::time::Instant;
+use tokio::time::Instant;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/tests/job_tests.rs
+++ b/tests/job_tests.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::needless_return)]
 #[cfg(test)]
-mod tests {
+mod job {
     use anyhow::Ok;
     use async_lazy::Lazy;
     use bull::*;

--- a/tests/job_tests.rs
+++ b/tests/job_tests.rs
@@ -29,13 +29,9 @@ mod job {
     async fn creating_a_new_job() -> anyhow::Result<()> {
         let queue = QUEUE.force().await;
 
-        let job = Job::<String, String>::new(
-            "test",
-            queue,
-            "test".to_string(),
-            JobOptions::default(),
-        )
-        .await?;
+        let job =
+            Job::<String, String>::new("test", queue, "test".to_string(), JobOptions::default())
+                .await?;
         assert_eq!(job.name, "test");
 
         Ok(())
@@ -48,7 +44,7 @@ mod job {
         let mut config = HashMap::new();
         config.insert("password", pass.as_str());
         let redis_opts = RedisOpts::from_string_map(config);
-        let  queue = Queue::new("test", redis_opts, QueueOptions::default()).await?;
+        let queue = Queue::new("test", redis_opts, QueueOptions::default()).await?;
         let mut client = queue.client.lock().await;
         let result: HashMap<String, String> =
             client.hgetall("bull:pinningQueue:207").await.unwrap();


### PR DESCRIPTION
## What does this PR resolve? 

Due to the nature of BoxFutures,  closures that return them to have owned values or references with static lifetimes. Currently, you can only run the workers using the run method taking a static reference. The timer implementation brings this about,  it limits running the worker unless a static own is created.

### How this PR fixes the issue
The methods from our worker that were to be called are moved outside our implementation and only the copied values are passed to the functions  and then boxed for the timer to run  inside their callback
### Other improvements
- [x] string slices (& str)  in other struct implementations are replaced with strings for now.
- [x]  Add Arc for most clones and Send types.
- [x] Removed lifetimes on various implementations i.e Job, options  and etc
- [x]  only turn off features used in our case for Tokio (fs, rt).
### Issues closed by PR
#30 
